### PR TITLE
Dealing with missing genotype classes or types of segregation in F1

### DIFF
--- a/R/plot_raw_data.R
+++ b/R/plot_raw_data.R
@@ -120,7 +120,7 @@ plot.onemap <- function(x, all=TRUE, ...) {
     if (is(x, "outcross")) {
         g <- g + scale_fill_manual(name="Genotype",
                                    values=c("#00A08A", "#5BBCD6",  "#F2AD00", "#F98400", "#FF0000"))
-        if (length(levels(x$variable))>20)
+        if (x$n.mar>20)
             g <- g + theme(axis.text.y = element_blank(), axis.ticks.y = element_blank())
         
         if (all==TRUE) g
@@ -163,9 +163,8 @@ create_dataframe_for_plot_outcross <- function(x) {
         F1.A$value <- factor(F1.A$value)
         if (!exists("F1.A.")) F1.A. <- data.frame(F1.A)
         else F1.A. <- rbind(F1.A.,F1.A)
-        }
+        } else F1.A. <- NULL
     }
-    class(F1.A.) <- "data.frame"
     # Markers of B type
     for (i in 1:3) {
     if (length(which(x$segr.type==paste("B",i,".",i+4,sep=""))!=0)) {
@@ -176,7 +175,7 @@ create_dataframe_for_plot_outcross <- function(x) {
         F1.B$value <- factor(F1.B$value)
         if (!exists("F1.B.")) F1.B. <- data.frame(F1.B)
         else F1.B. <- rbind(F1.B.,F1.B)
-        }
+        } else F1.B. <- NULL
     }
     # Markers of C type
     for (i in 8) {
@@ -188,7 +187,7 @@ create_dataframe_for_plot_outcross <- function(x) {
         F1.C$value <- factor(F1.C$value)
         if (!exists("F1.C.")) F1.C. <- data.frame(F1.C)
         else F1.C. <- rbind(F1.C.,F1.C)
-        }
+        } else F1.C. <- NULL
     }
     # Markers of D1 type
     for (i in 9:13) {
@@ -200,7 +199,7 @@ create_dataframe_for_plot_outcross <- function(x) {
         F1.D1$value <- factor(F1.D1$value)
         if (!exists("F1.D1.")) F1.D1. <- data.frame(F1.D1)
         else F1.D1. <- rbind(F1.D1.,F1.D1)
-        }
+        } else F1.D1. <- NULL
     }
     # Markers of D2 type
     for (i in 14:18) {
@@ -212,14 +211,15 @@ create_dataframe_for_plot_outcross <- function(x) {
         F1.D2$value <- factor(F1.D2$value)
         if (!exists("F1.D2.")) F1.D2. <- data.frame(F1.D2)
         else F1.D2. <- rbind(F1.D2.,F1.D2)
-        }
+        } else F1.D2. <- NULL
     }
     # Defining classes and combining
-    class(F1.A.) <- "data.frame"
-    class(F1.B.) <- "data.frame"
-    class(F1.C.) <- "data.frame"
-    class(F1.D1.) <- "data.frame"
-    class(F1.D2.) <- "data.frame"
+    # It was not working if any class was missing; now it is
+    if (!is.null(F1.A.)) class(F1.A.) <- "data.frame"
+    if (!is.null(F1.B.)) class(F1.B.) <- "data.frame"
+    if (!is.null(F1.C.)) class(F1.C.) <- "data.frame"
+    if (!is.null(F1.D1.)) class(F1.D1.) <- "data.frame"
+    if (!is.null(F1.D2.)) class(F1.D2.) <- "data.frame"
     return(rbind(F1.A.,F1.B.,F1.C.,F1.D1.,F1.D2.))
 }
 ##'

--- a/R/test_segregation.R
+++ b/R/test_segregation.R
@@ -33,7 +33,9 @@
 ##' @return a list with the H0 hypothesis being tested, the chi-square statistics,
 ##' the associated p-values, and the \% of individuals genotyped.
 ##'
-##'
+##' It returns \code{NA} if the numbers of expected and observed classes are 
+##' different or if dominant and co-dominant coding is mixed in the same marker.
+##' 
 ##' ##'@examples
 ##' data(fake.bc.onemap) # Loads a fake backcross dataset installed with onemap
 ##' test_segregation_of_a_marker(fake.bc.onemap,1)
@@ -42,35 +44,95 @@
 ##' test_segregation_of_a_marker(example.out,1)
 test_segregation_of_a_marker <- function(x, marker) {
     ## Segregation pattern for each marker type
-    p.a <- rep(1/4, 4); p.b <- c(1/4, 1/2, 1/4); p.c <- c(3/4,1/4); p.d <- rep(1/2, 2)
+    p.a <- rep(1/4, 4); p.b <- c(1/4, 1/2, 1/4); p.c <- c(3/4, 1/4); p.d <- rep(1/2, 2)
     ## Counting each category
     count <- table(x$geno[,marker], exclude=0)
     ## Do the chisq test, using the appropriate expected segregation
-    ## grepl() allows finding the marker type (it has the letter in the argument)    
+    ## grepl() allows finding the marker type (it has the letter in the argument)
+    ## Impossible to test markers with different number of expected and observed classes
     if (grepl("A.H.B",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=p.b, correct = FALSE)
-        H0 <- "1:2:1"}
+        if (dim(count) == 3) {
+            qui <- chisq.test(count, p=p.b, correct = FALSE)
+            H0 <- "1:2:1"
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     else if (grepl("C.A",x$segr.type[marker]) | grepl("D.B",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=rev(p.c), correct = FALSE)
-        H0 <- "3:1"}
+        if (dim(count) == 2) {
+            qui <- chisq.test(count, p=rev(p.c), correct = FALSE)
+            H0 <- "3:1"
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     else if (grepl("A.H",x$segr.type[marker]) | grepl("A.B",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=p.d, correct = FALSE)
-        H0 <- "1:1"}
+        if (dim(count) == 2) {
+            qui <- chisq.test(count, p=p.d, correct = FALSE)
+            H0 <- "1:1"
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     else if (grepl("A",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=p.a, correct = FALSE)
-        H0 <- "1:1:1:1" }
+        if (dim(count) == 4) {
+            qui <- chisq.test(count, p=p.a, correct = FALSE)
+            H0 <- "1:1:1:1"
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     else if (grepl("B",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=p.b, correct = FALSE)
-        H0 <- "1:2:1" }
+        if (dim(count) == 3) {
+            qui <- chisq.test(count, p=p.b, correct = FALSE)
+            H0 <- "1:2:1" 
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     else if (grepl("C",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=p.c, correct = FALSE)
-        H0 <- "3:1" }
+        if (dim(count) == 2) {
+            qui <- chisq.test(count, p=p.c, correct = FALSE)
+            H0 <- "3:1"
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     else if (grepl("D",x$segr.type[marker])) {
-        qui <- chisq.test(count, p=p.d, correct = FALSE)
-        H0 <- "1:1" }
+        if (dim(count) == 2) {
+            qui <- chisq.test(count, p=p.d, correct = FALSE)
+            H0 <- "1:1"
+        } else {
+            qui <- NULL
+            qui$statistic <- NA
+            qui$p.value <- NA
+            H0 <- NA
+        }
+    }
     #impossible to test: dominant and co-dominant mixed in the same marker
+    #however, it will not work with "qui <- NA"; using NULL instead
     else if (grepl("M.X",x$segr.type[marker])) { 
-        qui <- NA
+        qui <- NULL
+        qui$statistic <- NA
+        qui$p.value <- NA
         H0 <- NA
     }
     return(list(Hypothesis=H0, qui.quad=qui$statistic, p.val=qui$p.value,


### PR DESCRIPTION
Fixed bugs related with (1) `test_segregation()` function, which did not suppose different number of expected and observed classes when performing chi-square tests, and (2) `plot()` function for a `onemap` object, which did not suppose missing segregation types (A, B, C, D1 or D2), when, in general, real data miss one or more from those segregation types.
