### PR TITLE
Fixing the loop on group function

### DIFF
--- a/R/group.R
+++ b/R/group.R
@@ -163,7 +163,7 @@ print.group <-
                 cat(x$marnames[which(x$groups==i)], "\n")
             }
             if (any(is.na(x$groups))) {
-                cat("\n  Unlinked markers:", length(which(is.na(x$groups))) ," markers\n    ")
+                cat("\n  Unlinked markers:", length(which(x$groups==0)) ," markers\n    ")
                 #cat(x$marnames[x$seq.num[which(is.na(x$groups))]], "\n")
                 cat(x$marnames[which(x$groups==0)], "\n") 
             }

--- a/R/group.R
+++ b/R/group.R
@@ -162,7 +162,7 @@ print.group <-
                 #cat(x$marnames[x$seq.num[which(x$groups==i)]], "\n")
                 cat(x$marnames[which(x$groups==i)], "\n")
             }
-            if (any(is.na(x$groups))) {
+            if (any(x$groups==0)) {
                 cat("\n  Unlinked markers:", length(which(x$groups==0)) ," markers\n    ")
                 #cat(x$marnames[x$seq.num[which(is.na(x$groups))]], "\n")
                 cat(x$marnames[which(x$groups==0)], "\n") 

--- a/R/group.R
+++ b/R/group.R
@@ -77,9 +77,11 @@ group <- function(input.seq, LOD=NULL, max.rf=NULL, verbose=TRUE)
         max.rf <- get(input.seq$twopt, pos=1)$max.rf
     cl<-class(get(input.seq$data.name))[2]
     geno<-get(input.seq$data.name)$geno[,input.seq$seq.num]
-    st<-get(input.seq$data.name)$segr.type.num
+    #st<-get(input.seq$data.name)$segr.type.num
+    st<-get(input.seq$data.name)$segr.type.num[input.seq$seq.num]
     groups<-rep(0, length(input.seq$seq.num))
-    tp<-list(unlk=input.seq$seq.num)
+    #tp<-list(unlk=input.seq$seq.num)
+    tp<-list(unlk=1:length(input.seq$seq.num))
     i<-1
     if(verbose) cat("   Selecting markers: \n")
     while(length(tp$unlk) > 0)
@@ -157,11 +159,13 @@ print.group <-
             cat("\n  Printing groups:")
             for (i in 1:x$n.groups) {
                 cat("\n  Group", i, ":", length(which(x$groups==i)) , "markers\n    ")
-                cat(x$marnames[x$seq.num[which(x$groups==i)]], "\n")
+                #cat(x$marnames[x$seq.num[which(x$groups==i)]], "\n")
+                cat(x$marnames[which(x$groups==i)], "\n")
             }
             if (any(is.na(x$groups))) {
                 cat("\n  Unlinked markers:", length(which(is.na(x$groups))) ," markers\n    ")
-                cat(x$marnames[x$seq.num[which(is.na(x$groups))]], "\n")
+                #cat(x$marnames[x$seq.num[which(is.na(x$groups))]], "\n")
+                cat(x$marnames[which(x$groups==0)], "\n") 
             }
         }
     }

--- a/R/group.R
+++ b/R/group.R
@@ -9,7 +9,7 @@
 ## copyright (c) 2007-9, Gabriel R A Margarido and Marcelo Mollinari   ##
 ##                                                                     ##
 ## First version: 11/07/2007                                           ##
-## Last update: 01/14/2016                                             ##
+## Last update: 21/06/2016                                             ##
 ## License: GNU General Public License version 2 (June, 1991) or later ##
 ##                                                                     ##
 #######################################################################
@@ -77,10 +77,8 @@ group <- function(input.seq, LOD=NULL, max.rf=NULL, verbose=TRUE)
         max.rf <- get(input.seq$twopt, pos=1)$max.rf
     cl<-class(get(input.seq$data.name))[2]
     geno<-get(input.seq$data.name)$geno[,input.seq$seq.num]
-    #st<-get(input.seq$data.name)$segr.type.num
     st<-get(input.seq$data.name)$segr.type.num[input.seq$seq.num]
     groups<-rep(0, length(input.seq$seq.num))
-    #tp<-list(unlk=input.seq$seq.num)
     tp<-list(unlk=1:length(input.seq$seq.num))
     i<-1
     if(verbose) cat("   Selecting markers: \n")
@@ -159,12 +157,10 @@ print.group <-
             cat("\n  Printing groups:")
             for (i in 1:x$n.groups) {
                 cat("\n  Group", i, ":", length(which(x$groups==i)) , "markers\n    ")
-                #cat(x$marnames[x$seq.num[which(x$groups==i)]], "\n")
                 cat(x$marnames[which(x$groups==i)], "\n")
             }
             if (any(x$groups==0)) {
                 cat("\n  Unlinked markers:", length(which(x$groups==0)) ," markers\n    ")
-                #cat(x$marnames[x$seq.num[which(is.na(x$groups))]], "\n")
                 cat(x$marnames[which(x$groups==0)], "\n") 
             }
         }


### PR DESCRIPTION
We tested the corrected function and worked as expected.

The function was giving dimension error if using a make.seq object without a order initiated by 1 (for example markers 1,2,3,4,5...) or with skipped positions. For example:

----- R CODE -----

> data(example_out)
> twopts <- rf_2pts(example_out)
> Computing 435 recombination fractions ... 
> less.data <- make_seq(twopts,c(2,3,4))
> link_gr <- group(less.data)
>    Selecting markers: 
> Error in geno[, c(i, s)] : subscript out of bounds

----- END OF R CODE -----

To fix it, I changed the following lines
Line 80 Changed to just use the segr.type.num of the input.seq
Line 83: Changed to a simple sequence to not screw up the For
Line 162 and 168: Changed to the new parameters of the group function loop (given the Line 83 changed)
Line 166 and 165: Changed to correct print and get the unlinked markers of group class  
