### PR TITLE
Updating DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,11 +17,12 @@ Authors@R: c(person("Gabriel", "Margarido", role = "aut", email =
         "augusto.garcia@usp.br"))
 Author: Gabriel Margarido [aut]
 LinkingTo: Rcpp (>= 0.10.5), Rhtslib, zlibbioc
+Depends:
+     R (>= 3.2.0)
 Imports:
     tcltk (>= 3.2.0),
     tkrplot (>= 0.0-23),
     ggplot2 (>= 2.2.1),
-    R (>= 3.2.0)
     fields (>= 8.3-5),
     reshape2 (>= 1.4.1)
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ LinkingTo: Rcpp (>= 0.10.5), Rhtslib, zlibbioc
 Depends:
     tcltk (>= 3.2.0),
     tkrplot (>= 0.0-23),
-    ggplot2 (>= 1.0.1),
+    ggplot2 (>= 2.2.1),
     R (>= 3.2.0)
 Imports:
     fields (>= 8.3-5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     tkrplot (>= 0.0-23),
     ggplot2 (>= 2.2.1),
     fields (>= 8.3-5),
-    reshape2 (>= 1.4.1)
+    reshape2 (>= 1.4.1),
+    spam (>= 1.4-0)
 Suggests:
     qtl (>= 1.36-6),
     knitr (>= 1.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Authors@R: c(person("Gabriel", "Margarido", role = "aut", email =
 Author: Gabriel Margarido [aut]
 LinkingTo: Rcpp (>= 0.10.5), Rhtslib, zlibbioc
 Depends:
-     R (>= 3.2.0)
+     R (>= 3.4.0)
 Imports:
     tcltk (>= 3.2.0),
     tkrplot (>= 0.0-23),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,9 @@ Imports:
     ggplot2 (>= 2.2.1),
     fields (>= 8.3-5),
     reshape2 (>= 1.4.1),
-    spam (>= 1.4-0)
+    spam (>= 1.4-0),
+    maps (>= 3.1.1),
+    stringr (>= 1.2.0)
 Suggests:
     qtl (>= 1.36-6),
     knitr (>= 1.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,9 @@ Imports:
     reshape2 (>= 1.4.1),
     spam (>= 1.4-0),
     maps (>= 3.1.1),
-    stringr (>= 1.2.0)
+    stringr (>= 1.2.0),
+    Rhtslib (>= 1.8.0),
+    zlibbioc (>= 1.22.0)
 Suggests:
     qtl (>= 1.36-6),
     knitr (>= 1.10)
@@ -42,3 +44,4 @@ Packaged: 2013-09-09 16:55:07 UTC; mmollina
 NeedsCompilation: yes
 Date/Publication: 2013-09-09 20:03:53
 RoxygenNote: 5.0.1
+biocViews:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,12 +17,11 @@ Authors@R: c(person("Gabriel", "Margarido", role = "aut", email =
         "augusto.garcia@usp.br"))
 Author: Gabriel Margarido [aut]
 LinkingTo: Rcpp (>= 0.10.5), Rhtslib, zlibbioc
-Depends:
+Imports:
     tcltk (>= 3.2.0),
     tkrplot (>= 0.0-23),
     ggplot2 (>= 2.2.1),
     R (>= 3.2.0)
-Imports:
     fields (>= 8.3-5),
     reshape2 (>= 1.4.1)
 Suggests:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ library(devtools)
 
 This will allow you to automatically build and install packages from
 github. If you use Windows, first install
-[Rtools](https://cran.r-project.org/bin/windows/Rtools/). On a Mac,
+[Rtools](https://cran.r-project.org/bin/windows/Rtools/). If you are facing problems with Rtools installation, try to do it by selecting *Run as Admnistrator* option with right mouse button. On a Mac,
 you will need Xcode (available on the App Store). On Linux, you are
 good to go.
 


### PR DESCRIPTION
DESCRIPTION file was not up-to-date with the new requirements. Because of that, some Windows users were facing troubles while installing it. I've also changed the packages on "_depends_" to "_imports_" this may avoid further conflicts (see more at: http://r-pkgs.had.co.nz/description.html and http://stackoverflow.com/questions/8637993/better-explanation-of-when-to-use-imports-depends). We have some trouble on this issue in the package. So, I believe it is better to keep all in the imports section. I included a way to install Bioconductor packages, it is the _biocViews:_ at the end. At last, I changed the R version to 3.4.0. It is the newer version and the one which I used to check the installs. I check it in a Windows 7 and it is fully working/installing.
Best,
Rodrigo