### PR TITLE
Fixing minor conflicts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ addons:
     packages:
       - r-cran-tkrplot
       - tk-dev
-bioc_packages:
- - Rhtslib
- - zlibbioc
 
 r_build_args: --no-build-vignettes
 r_check_args: --no-vignettes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(person("Gabriel", "Margarido", role = "aut", email =
         person("Augusto", "Garcia", role = c("aut", "ctb"), email =
         "augusto.garcia@usp.br"))
 Author: Gabriel Margarido [aut]
-LinkingTo: Rcpp (>= 0.10.5)
+LinkingTo: Rcpp (>= 0.10.5), Rhtslib, zlibbioc
 Depends:
      R (>= 3.4.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(person("Gabriel", "Margarido", role = "aut", email =
         person("Augusto", "Garcia", role = c("aut", "ctb"), email =
         "augusto.garcia@usp.br"))
 Author: Gabriel Margarido [aut]
-LinkingTo: Rcpp (>= 0.10.5), Rhtslib, zlibbioc
+LinkingTo: Rcpp (>= 0.10.5)
 Depends:
      R (>= 3.4.0)
 Imports:
@@ -25,9 +25,6 @@ Imports:
     ggplot2 (>= 2.2.1),
     fields (>= 8.3-5),
     reshape2 (>= 1.4.1),
-    spam (>= 1.4-0),
-    maps (>= 3.1.1),
-    stringr (>= 1.2.0),
     Rhtslib (>= 1.8.0),
     zlibbioc (>= 1.22.0)
 Suggests:

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 useDynLib(onemap)
 
 ## Import all packages listed as Imports or Depends
-import(tcltk, tkrplot, ggplot2)
+import(tcltk, tkrplot, ggplot2, Rhtslib, zlibbioc)
 importFrom(fields, tim.colors)
 importFrom(fields, splint)
 

--- a/R/plot_raw_data.R
+++ b/R/plot_raw_data.R
@@ -51,7 +51,7 @@ globalVariables(c("Type", "segr.type"))
 ##' # You can store the graphic in an object, then save it with a number of properties
 ##' # For details, see the help of ggplot2's function ggsave()
 ##' g <- plot(fake_bc_onemap)
-##' ggplot2::("MyRawData_bc.jpg", g, width=7, height=4, dpi=600)
+##' ggplot2::ggsave("MyRawData_bc.jpg", g, width=7, height=4, dpi=600)
 ##'
 ##' data(fake_f2_onemap) # Loads a fake backcross dataset installed with onemap
 ##' plot(fake_f2_onemap) # This will show you the graph

--- a/R/plot_raw_data.R
+++ b/R/plot_raw_data.R
@@ -51,7 +51,7 @@ globalVariables(c("Type", "segr.type"))
 ##' # You can store the graphic in an object, then save it with a number of properties
 ##' # For details, see the help of ggplot2's function ggsave()
 ##' g <- plot(fake_bc_onemap)
-##' ggsave("MyRawData_bc.jpg", g, width=7, height=4, dpi=600)
+##' ggplot2::("MyRawData_bc.jpg", g, width=7, height=4, dpi=600)
 ##'
 ##' data(fake_f2_onemap) # Loads a fake backcross dataset installed with onemap
 ##' plot(fake_f2_onemap) # This will show you the graph
@@ -59,7 +59,7 @@ globalVariables(c("Type", "segr.type"))
 ##' # You can store the graphic in an object, then save it with a number of properties
 ##' # For details, see the help of ggplot2's function ggsave()
 ##' g <- plot(fake_f2_onemap)
-##' ggsave("MyRawData_f2.jpg", g, width=7, height=4, dpi=600)
+##' ggplot2::ggsave("MyRawData_f2.jpg", g, width=7, height=4, dpi=600)
 ##'
 ##' data(example_out) # Loads a fake full-sib dataset installed with onemap
 ##' plot(example_out) # This will show you the graph for all markers
@@ -68,7 +68,7 @@ globalVariables(c("Type", "segr.type"))
 ##' # You can store the graphic in an object, then save it.
 ##' # For details, see the help of ggplot2's function ggsave()
 ##' g <- plot(example_out, all=FALSE)
-##' ggsave("MyRawData_out.jpg", g, width=9, height=4, dpi=600)
+##' ggplot2::ggsave("MyRawData_out.jpg", g, width=9, height=4, dpi=600)
 ##'
 ##' @export
 plot.onemap <- function(x, all=TRUE, ...) {

--- a/R/test_segregation.R
+++ b/R/test_segregation.R
@@ -236,7 +236,7 @@ print.onemap_segreg_test <- function(x,...) {
 ##' # You can store the graphic in an object, then save it.
 ##' # For details, see the help of ggplot2's function ggsave()
 ##' g <- plot(BC.seg)
-##' ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
+##' ggplot2::ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
 ##'
 ##' data(example_out) # load OneMap's fake dataset for an outcrossing population
 ##' Out.seg <- test_segregation(example_out) # Applies chi-square tests
@@ -246,7 +246,7 @@ print.onemap_segreg_test <- function(x,...) {
 ##' # You can store the graphic in an object, then save it.
 ##' # For details, see the help of ggplot2's function ggsave()
 ##' g <- plot(Out.seg)
-##' ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
+##' ggplot2::ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
 ##'
 ##' @export
 plot.onemap_segreg_test <- function(x, order=TRUE,...) {

--- a/man/plot.onemap.Rd
+++ b/man/plot.onemap.Rd
@@ -37,7 +37,7 @@ plot(fake_bc_onemap) # This will show you the graph
 # You can store the graphic in an object, then save it with a number of properties
 # For details, see the help of ggplot2's function ggsave()
 g <- plot(fake_bc_onemap)
-ggsave("MyRawData_bc.jpg", g, width=7, height=4, dpi=600)
+ggplot2::ggsave("MyRawData_bc.jpg", g, width=7, height=4, dpi=600)
 
 data(fake_f2_onemap) # Loads a fake backcross dataset installed with onemap
 plot(fake_f2_onemap) # This will show you the graph
@@ -45,7 +45,7 @@ plot(fake_f2_onemap) # This will show you the graph
 # You can store the graphic in an object, then save it with a number of properties
 # For details, see the help of ggplot2's function ggsave()
 g <- plot(fake_f2_onemap)
-ggsave("MyRawData_f2.jpg", g, width=7, height=4, dpi=600)
+ggplot2::ggsave("MyRawData_f2.jpg", g, width=7, height=4, dpi=600)
 
 data(example_out) # Loads a fake full-sib dataset installed with onemap
 plot(example_out) # This will show you the graph for all markers
@@ -54,7 +54,7 @@ plot(example_out, all=FALSE) # This will show you the graph splitted for marker 
 # You can store the graphic in an object, then save it.
 # For details, see the help of ggplot2's function ggsave()
 g <- plot(example_out, all=FALSE)
-ggsave("MyRawData_out.jpg", g, width=9, height=4, dpi=600)
+ggplot2::ggsave("MyRawData_out.jpg", g, width=9, height=4, dpi=600)
 
 }
 

--- a/man/plot.onemap_segreg_test.Rd
+++ b/man/plot.onemap_segreg_test.Rd
@@ -33,7 +33,7 @@ plot(BC.seg, order=FALSE) # Plot the graph showing the results keeping the order
 # You can store the graphic in an object, then save it.
 # For details, see the help of ggplot2's function ggsave()
 g <- plot(BC.seg)
-ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
+ggplot2::ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
 
 data(example_out) # load OneMap's fake dataset for an outcrossing population
 Out.seg <- test_segregation(example_out) # Applies chi-square tests
@@ -43,7 +43,7 @@ plot(Out.seg, order=FALSE) # Plot the graph showing the results keeping the orde
 # You can store the graphic in an object, then save it.
 # For details, see the help of ggplot2's function ggsave()
 g <- plot(Out.seg)
-ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
+ggplot2::ggsave("SegregationTests.jpg", g, width=7, height=5, dpi=600)
 
 }
 

--- a/man/plot_by_segreg_type.Rd
+++ b/man/plot_by_segreg_type.Rd
@@ -35,7 +35,7 @@ plot_by_segreg_type(fake_f2_onemap)
 # For details, see the help of ggplot2's function ggsave()
 data(example_out) #Outcrossing data
 g <- plot_by_segreg_type(example_out)
-ggsave("SegregationTypes.jpg", g, width=7, height=4, dpi=600)
+ggplot2::ggsave("SegregationTypes.jpg", g, width=7, height=4, dpi=600)
 
 }
 


### PR DESCRIPTION
At DESCRIPTION, I removed the dependencies of dependencies which were not onemap's dependents. For example, stringr was the dependence of reshape2, but not a direct dependence of onemap.

At plot_raw_data.R and MAN files, I replaced ggsave to ggplot2::ggsave, because of ggplot2 went to _imports_ and not _depends_ DESCRIPTION section now it just loads it in the onemap's env., not in the user's env. 

I reran the Travis check and it is not getting any error, just the earlier warnings. But double-check it.
Best,
Rodrigo 