### PR TITLE
Update onemap_read_vcfR.R to save cross types consistently with other functions 

### DIFF
--- a/R/onemap_read_vcfR.R
+++ b/R/onemap_read_vcfR.R
@@ -229,7 +229,8 @@ onemap_read_vcfR <- function(vcfR.object=NULL,
   rownames(GT_matrix) <- MKS
   colnames(GT_matrix) <- INDS[-c(P1,P2)] 
   
-  
+  legacy_crosses <- setNames(c("outcross", "f2", "backcross", "riself", "risib"), 
+                             c("outcross", "f2 intercross", "f2 backcross", "ri self", "ri sib"))
   structure(list(geno= t(GT_matrix),
                  n.ind = dim(GT_matrix)[2],
                  n.mar = n.mk,
@@ -240,5 +241,5 @@ onemap_read_vcfR <- function(vcfR.object=NULL,
                  CHROM = CHROM,
                  POS = POS,
                  input = "vcfR.object"),
-            class=c("onemap",cross))
+            class=c("onemap",legacy_crosses[cross]))
 }


### PR DESCRIPTION
Save the output cross as the "old" cross types (from version 1.xx), so other functions will keep working (`adjust_rils.R, codif_data.R, cpp_utils.R, group.R, make_seq.R, map.R, order_seq.R, plot_raw_data.R, rf_2pts.R, rf_graph_table.R` - all these depend on the former cross types) and also to be consistent with the output of `read_mapmaker.R` and `read_onemap.R`.
The "new" cross type will be saved in `names(class(onemap_obj)[2])` and can be used.