### PR TITLE
Bug fix in compare function.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: onemap
 Title: Construction of Genetic Maps in Experimental Crosses: Full-Sib,
         RILs, F2 and Backcrosses
-Version: 2.1.2000
+Version: 2.1.2001
 Description: Analysis of molecular marker data from model (backcrosses,
     F2 and recombinant inbred lines) and non-model systems (i. e.
     outcrossing species). For the later, it allows statistical

--- a/man/onemap-internal.Rd
+++ b/man/onemap-internal.Rd
@@ -6,7 +6,8 @@
 \alias{codif_data}
 \alias{comb}
 \alias{comb_ger}
-\alias{compare_inbred}
+\alias{compare_inbred_f2}
+\alias{compare_inbred_bc}
 \alias{compare_outcross}
 \alias{Cindex}
 \alias{diplo}
@@ -52,7 +53,8 @@ codif_data(geno.in,segr.type.in,cross = c("outcross", "f2", "backcross",
 "riself", "risib"))
 comb(x,y)
 comb_ger(f)
-compare_inbred(input.seq, n.best, tol, verbose = FALSE)
+compare_inbred_bc(input.seq, n.best, tol, verbose = FALSE)
+compare_inbred_f2(input.seq, n.best, tol, verbose = FALSE)
 compare_outcross(input.seq, n.best, tol, verbose)
 Cindex(order,r)
 diplo(w, seq.num, seq.phases)


### PR DESCRIPTION
For inbreed derived populations (F2, BC, and RILs), the 'compare' function was recalculating the final map, assuming an F2 population. In real situations, since we usually have more than ten markers, 'compare' is used to propose an initial order and not final maps. After that, the remaining markers are added to that sequence and the final map was recalculated by the adequate est_map_hmm functions. Thus, this would rarely cause any problems in real datasets. 