### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ You can read _OneMap_ tutorials going to the vignettes of the
 installed package, or clicking below. Please, start with the overview,
 that will guide you through other chapters.
 
-1. [Overview](https://augusto-garcia.github.io/onemap/vignettes_highres/Overview.html)
+1. [Overview](https://statgen-esalq.github.io/tutorials/onemap/Overview.html)
 
-2. [Introduction to R](https://augusto-garcia.github.io/onemap/vignettes_highres/Introduction_R.html)
+2. [Introduction to R](https://statgen-esalq.github.io/tutorials/onemap/Introduction_R.html)
 
-3. [How to build a linkage map for inbred-bases populations (F2, RIL and BC)](http://augusto-garcia.github.io/onemap/vignettes_highres/Inbred_Based_Populations.html)
+3. [How to build a linkage map for inbred-bases populations (F2, RIL and BC)](https://statgen-esalq.github.io/tutorials/onemap/Inbred_Based_Populations.html)
 
-4. [How to build a linkage map for outcrossing populations](http://augusto-garcia.github.io/onemap/vignettes_highres/Outcrossing_Populations.html)
+4. [How to build a linkage map for outcrossing populations](https://statgen-esalq.github.io/tutorials/onemap/Outcrossing_Populations.html)
 


### PR DESCRIPTION
A directory in statgen-esalq github profile was create to store the high resolution vignettes. Keeping them in the onemap repository was masking the repository programming language type.